### PR TITLE
Add JSDocs to all exported symbols

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,13 +1,22 @@
+/**
+ * Represents the validity start height for a transaction.
+ */
 export type ValidityStartHeight =
   | { relativeValidityStartHeight: number }
   | { absoluteValidityStartHeight: number }
 
+/**
+ * Enum representing different hash algorithms.
+ */
 export enum HashAlgorithm {
   Blake2b = 1,
   Sha256 = 3,
   Sha512 = 4,
 }
 
+/**
+ * Enum representing different account types.
+ */
 export enum AccountType {
   Basic = 'basic',
   Vesting = 'vesting',
@@ -15,6 +24,9 @@ export enum AccountType {
   Staking = 'staking',
 }
 
+/**
+ * Enum representing different inherent types.
+ */
 export enum InherentType {
   Reward = 'reward',
   Jail = 'jail',
@@ -101,12 +113,18 @@ export interface PolicyConstants {
   blockSeparationTime: number
 }
 
+/**
+ * Represents a basic account in the blockchain.
+ */
 export interface BasicAccount {
   type: AccountType.Basic
   address: string
   balance: number
 }
 
+/**
+ * Represents a vesting account in the blockchain.
+ */
 export interface VestingAccount {
   type: AccountType.Vesting
   address: string
@@ -118,6 +136,9 @@ export interface VestingAccount {
   vestingTotalAmount: number
 }
 
+/**
+ * Represents an HTLC (Hashed Time-Locked Contract) account in the blockchain.
+ */
 export interface HtlcAccount {
   type: AccountType.HTLC
   address: string
@@ -130,13 +151,23 @@ export interface HtlcAccount {
   totalAmount: number
 }
 
+/**
+ * Represents a staking account in the blockchain.
+ */
 export interface StakingAccount {
   type: AccountType.Staking
   address: string
   balance: number
 }
 
+/**
+ * Represents an account in the blockchain, which can be of different types.
+ */
 export type Account = BasicAccount | VestingAccount | HtlcAccount | StakingAccount
+
+/**
+ * Represents a transaction in the blockchain.
+ */
 export interface Transaction {
   hash: string
   blockNumber?: number // Optional, corresponds to Option<u32>
@@ -158,6 +189,9 @@ export interface Transaction {
   networkId: number // Corresponds to u8
 }
 
+/**
+ * Represents a staker in the blockchain.
+ */
 export interface Staker {
   address: string
   balance: number
@@ -167,6 +201,9 @@ export interface Staker {
   retiredBalance: number
 }
 
+/**
+ * Represents a validator in the blockchain.
+ */
 export interface Validator {
   address: string
   signingKey: string
@@ -176,26 +213,29 @@ export interface Validator {
   balance: number
 
   /**
-   * The total amount of stakers in the valiator
+   * The total amount of stakers in the validator.
    */
   numStakers: number
 
   /**
-   * Wether the validator has been retired
+   * Whether the validator has been retired.
    */
   retired: boolean
 
   /**
-   * The block in which the validator was inactive from
+   * The block in which the validator was inactive from.
    */
   inactivityFlag?: number
 
   /**
-   * The block in which the validator was jailed from
+   * The block in which the validator was jailed from.
    */
   jailedFrom?: number
 }
 
+/**
+ * Represents a slot in the blockchain.
+ */
 export interface Slot {
   firstSlotNumber: number
   numSlots: number
@@ -203,11 +243,17 @@ export interface Slot {
   publicKey: string
 }
 
+/**
+ * Represents penalized slots in the blockchain.
+ */
 export interface PenalizedSlots {
   blockNumber: number
   disabled: number[]
 }
 
+/**
+ * Represents an inherent reward in the blockchain.
+ */
 export interface InherentReward {
   type: InherentType.Reward
   blockNumber: number
@@ -218,6 +264,9 @@ export interface InherentReward {
   hash: string
 }
 
+/**
+ * Represents an inherent penalize action in the blockchain.
+ */
 export interface InherentPenalize {
   type: InherentType.Penalize
   blockNumber: number
@@ -226,6 +275,9 @@ export interface InherentPenalize {
   offenseEventBlock: number
 }
 
+/**
+ * Represents an inherent jail action in the blockchain.
+ */
 export interface InherentJail {
   type: InherentType.Jail
   blockNumber: number
@@ -234,8 +286,14 @@ export interface InherentJail {
   offenseEventBlock: number
 }
 
+/**
+ * Represents an inherent action in the blockchain, which can be of different types.
+ */
 export type Inherent = InherentReward | InherentPenalize | InherentJail
 
+/**
+ * Represents information about the mempool in the blockchain.
+ */
 export interface MempoolInfo {
   _0?: number
   _1?: number
@@ -255,44 +313,68 @@ export interface MempoolInfo {
   buckets: number[]
 }
 
+/**
+ * Represents a wallet account in the blockchain.
+ */
 export interface WalletAccount {
   address: string
   publicKey: string
   privateKey: string
 }
 
+/**
+ * Represents a signature in the blockchain.
+ */
 export interface Signature {
   signature: string
   publicKey: string
 }
 
+/**
+ * Represents the state of the ZKP (Zero-Knowledge Proof) component in the blockchain.
+ */
 export interface ZKPState {
   latestBlock: Block
   latestProof?: string
 }
 
+/**
+ * Represents the state of the blockchain.
+ */
 export interface BlockchainState {
   blockNumber: number
   blockHash: string
 }
 
+/**
+ * Enum representing different block types.
+ */
 export enum BlockType {
   Micro = 'micro',
   Macro = 'macro',
 }
 
+/**
+ * Enum representing different block subscription types.
+ */
 export enum BlockSubscriptionType {
   Macro = 'macro',
   Micro = 'micro',
   Election = 'election',
 }
 
+/**
+ * Enum representing different retrieve types.
+ */
 export enum RetrieveType {
   Full = 'full',
   Partial = 'partial',
   Hash = 'hash',
 }
 
+/**
+ * Enum representing different network IDs.
+ */
 enum NetworkId {
   Test = 1,
   Dev = 2,
@@ -306,26 +388,40 @@ enum NetworkId {
   MainAlbatross = 24,
 }
 
+/**
+ * Represents a fork proof in the blockchain.
+ */
 export interface ForkProof {
   blockNumber: number
   hashes: [string, string]
 }
 
+/**
+ * Represents a double proposal proof in the blockchain.
+ */
 export interface DoubleProposalProof {
   blockNumber: number
   hashes: [string, string]
 }
 
+/**
+ * Represents a double vote proof in the blockchain.
+ */
 export interface DoubleVoteProof {
   blockNumber: number
 }
 
+/**
+ * Represents an equivocation proof in the blockchain, which can be of different types.
+ */
 export type EquivocationProof =
   | { type: 'Fork', proof: ForkProof }
   | { type: 'DoubleProposal', proof: DoubleProposalProof }
   | { type: 'DoubleVote', proof: DoubleVoteProof }
 
-// Block types
+/**
+ * Represents a partial block in the blockchain.
+ */
 export interface PartialBlock {
   hash: string
   size: number
@@ -343,6 +439,9 @@ export interface PartialBlock {
   transactions?: Transaction[]
 }
 
+/**
+ * Represents a partial micro block in the blockchain.
+ */
 export interface PartialMicroBlock extends PartialBlock {
   type: BlockType.Micro
   producer: {
@@ -365,6 +464,9 @@ export interface PartialMicroBlock extends PartialBlock {
   parentElectionHash?: undefined
 }
 
+/**
+ * Represents a micro block in the blockchain.
+ */
 export interface MicroBlock extends PartialMicroBlock {
   transactions: Transaction[]
   isElectionBlock?: undefined
@@ -375,6 +477,9 @@ export interface MicroBlock extends PartialMicroBlock {
   nextBatchInitialPunishedSet?: undefined
 }
 
+/**
+ * Represents a partial macro block in the blockchain.
+ */
 export interface PartialMacroBlock extends PartialBlock {
   type: BlockType.Macro
   epoch: number
@@ -383,6 +488,9 @@ export interface PartialMacroBlock extends PartialBlock {
   equivocationProofs?: undefined
 }
 
+/**
+ * Represents a macro block in the blockchain.
+ */
 export interface MacroBlock extends PartialMacroBlock {
   isElectionBlock: false
   transactions: Transaction[]
@@ -400,6 +508,9 @@ export interface MacroBlock extends PartialMacroBlock {
   nextBatchInitialPunishedSet?: undefined
 }
 
+/**
+ * Represents an election macro block in the blockchain.
+ */
 export interface ElectionMacroBlock extends PartialMacroBlock {
   isElectionBlock: true
   transactions: Transaction[]
@@ -408,4 +519,7 @@ export interface ElectionMacroBlock extends PartialMacroBlock {
   nextBatchInitialPunishedSet: number[]
 }
 
+/**
+ * Represents a block in the blockchain, which can be of different types.
+ */
 export type Block = MicroBlock | MacroBlock | ElectionMacroBlock

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,2 +1,9 @@
-export * from './common.ts'
-export * from './logs.ts'
+/**
+ * Common types used throughout the application.
+ */
+export * from './common.ts';
+
+/**
+ * Types related to logs and logging.
+ */
+export * from './logs.ts';

--- a/src/types/logs.ts
+++ b/src/types/logs.ts
@@ -1,5 +1,8 @@
 import type { BlockchainState } from './common.ts'
 
+/**
+ * Enum representing different log types.
+ */
 export enum LogType {
   PayFee = 'pay-fee',
   Transfer = 'transfer',
@@ -30,12 +33,18 @@ export enum LogType {
   FailedTransaction = 'failed-transaction',
 }
 
+/**
+ * Log representing a fee payment.
+ */
 export interface PayFeeLog {
   type: LogType.PayFee
   from: string
   fee: number
 }
 
+/**
+ * Log representing a transfer.
+ */
 export interface TransferLog {
   type: LogType.Transfer
   from: string
@@ -44,6 +53,9 @@ export interface TransferLog {
   data?: Uint8Array
 }
 
+/**
+ * Log representing the creation of an HTLC.
+ */
 export interface HtlcCreateLog {
   type: LogType.HtlcCreate
   contractAddress: string
@@ -55,11 +67,17 @@ export interface HtlcCreateLog {
   totalAmount: number
 }
 
+/**
+ * Log representing the timeout resolution of an HTLC.
+ */
 export interface HtlcTimeoutResolveLog {
   type: LogType.HtlcTimeoutResolve
   contractAddress: string
 }
 
+/**
+ * Log representing a regular transfer in an HTLC.
+ */
 export interface HtlcRegularTransferLog {
   type: LogType.HtlcRegularTransfer
   contractAddress: string
@@ -67,11 +85,17 @@ export interface HtlcRegularTransferLog {
   hashDepth: number
 }
 
+/**
+ * Log representing the early resolution of an HTLC.
+ */
 export interface HtlcEarlyResolveLog {
   type: LogType.HtlcEarlyResolve
   contractAddress: string
 }
 
+/**
+ * Log representing the creation of a vesting contract.
+ */
 export interface VestingCreateLog {
   type: LogType.VestingCreate
   contractAddress: string
@@ -82,12 +106,18 @@ export interface VestingCreateLog {
   vestingTotalAmount: number
 }
 
+/**
+ * Log representing the creation of a validator.
+ */
 export interface CreateValidatorLog {
   type: LogType.CreateValidator
   validatorAddress: string
   rewardAddress: string
 }
 
+/**
+ * Log representing the update of a validator.
+ */
 export interface UpdateValidatorLog {
   type: LogType.UpdateValidator
   validatorAddress: string
@@ -95,34 +125,52 @@ export interface UpdateValidatorLog {
   newRewardAddress: string | null
 }
 
+/**
+ * Log representing a fee deduction for a validator.
+ */
 export interface ValidatorFeeDeductionLog {
   type: LogType.ValidatorFeeDeduction
   validatorAddress: string
   fee: number
 }
 
+/**
+ * Log representing the deactivation of a validator.
+ */
 export interface DeactivateValidatorLog {
   type: LogType.DeactivateValidator
   validatorAddress: string
   inactiveFrom: number
 }
 
+/**
+ * Log representing the reactivation of a validator.
+ */
 export interface ReactivateValidatorLog {
   type: LogType.ReactivateValidator
   validatorAddress: string
 }
 
+/**
+ * Log representing the retirement of a validator.
+ */
 export interface RetireValidatorLog {
   type: LogType.RetireValidator
   validatorAddress: string
 }
 
+/**
+ * Log representing the deletion of a validator.
+ */
 export interface DeleteValidatorLog {
   type: LogType.DeleteValidator
   validatorAddress: string
   rewardAddress: string
 }
 
+/**
+ * Log representing the creation of a staker.
+ */
 export interface CreateStakerLog {
   type: LogType.CreateStaker
   stakerAddress: string
@@ -130,6 +178,9 @@ export interface CreateStakerLog {
   value: number
 }
 
+/**
+ * Log representing a stake action.
+ */
 export interface StakeLog {
   type: LogType.Stake
   stakerAddress: string
@@ -137,6 +188,9 @@ export interface StakeLog {
   value: number
 }
 
+/**
+ * Log representing the update of a staker.
+ */
 export interface UpdateStakerLog {
   type: LogType.UpdateStaker
   stakerAddress: string
@@ -146,6 +200,9 @@ export interface UpdateStakerLog {
   inactiveFrom: number | null
 }
 
+/**
+ * Log representing the setting of an active stake.
+ */
 export interface SetActiveStakeLog {
   type: LogType.SetActiveStake
   stakerAddress: string
@@ -155,6 +212,9 @@ export interface SetActiveStakeLog {
   inactiveFrom: number | null
 }
 
+/**
+ * Log representing the retirement of a stake.
+ */
 export interface RetireStakeLog {
   type: LogType.RetireStake
   stakerAddress: string
@@ -164,6 +224,9 @@ export interface RetireStakeLog {
   retiredBalance: number
 }
 
+/**
+ * Log representing the removal of a stake.
+ */
 export interface RemoveStakeLog {
   type: LogType.RemoveStake
   stakerAddress: string
@@ -171,24 +234,36 @@ export interface RemoveStakeLog {
   value: number
 }
 
+/**
+ * Log representing the deletion of a staker.
+ */
 export interface DeleteStakerLog {
   type: LogType.DeleteStaker
   stakerAddress: string
   validatorAddress: string | null
 }
 
+/**
+ * Log representing a fee deduction for a staker.
+ */
 export interface StakerFeeDeductionLog {
   type: LogType.StakerFeeDeduction
   stakerAddress: string
   fee: number
 }
 
+/**
+ * Log representing a reward payout.
+ */
 export interface PayoutRewardLog {
   type: LogType.PayoutReward
   to: string
   value: number
 }
 
+/**
+ * Log representing a penalization.
+ */
 export interface PenalizeLog {
   type: LogType.Penalize
   validatorAddress: string
@@ -197,17 +272,26 @@ export interface PenalizeLog {
   newlyDeactivated: boolean
 }
 
+/**
+ * Log representing the jailing of a validator.
+ */
 export interface JailValidatorLog {
   type: LogType.JailValidator
   validatorAddress: string
   jailedFrom: number
 }
 
+/**
+ * Log representing the reversion of a contract.
+ */
 export interface RevertContractLog {
   type: LogType.RevertContract
   contractAddress: string
 }
 
+/**
+ * Log representing a failed transaction.
+ */
 export interface FailedTransactionLog {
   type: LogType.FailedTransaction
   from: string
@@ -215,6 +299,9 @@ export interface FailedTransactionLog {
   failureReason: string
 }
 
+/**
+ * Union type representing all possible logs.
+ */
 export type Log =
   | PayFeeLog
   | TransferLog
@@ -244,32 +331,55 @@ export type Log =
   | RevertContractLog
   | FailedTransactionLog
 
+/**
+ * Represents a transaction log.
+ */
 export interface TransactionLog {
   hash: string
   logs: Log[]
   failed: boolean
 }
 
+/**
+ * Represents a block log.
+ */
 export interface BlockLog {
   inherents: Log[]
   transactions: TransactionLog[]
 }
 
+/**
+ * Represents an applied block log.
+ */
 export interface AppliedBlockLog extends BlockLog {
   type: 'applied-block'
   timestamp: bigint
 }
 
+/**
+ * Represents a reverted block log.
+ */
 export interface RevertedBlockLog extends BlockLog {
   type: 'reverted-block'
 }
 
+/**
+ * Union type representing all possible block log types.
+ */
 export type BlockLogType = AppliedBlockLog | RevertedBlockLog
 
+/**
+ * Represents the data returned by an RPC call.
+ *
+ * @template T - The type of the data.
+ * @template M - The type of the metadata.
+ */
 export interface RPCData<T, M = undefined> {
   data: T
   metadata: M
 }
 
-// Example usage of RPCData with BlockLogType and BlockchainState
+/**
+ * Represents the response of a block log RPC call.
+ */
 export type BlockLogResponse = RPCData<BlockLogType, BlockchainState>


### PR DESCRIPTION
Add JSDocs to all exported symbols in `src/types/index.ts`, `src/types/common.ts`, and `src/types/logs.ts`.

* **src/types/index.ts**
  - Add JSDocs for the exported symbols `./common.ts` and `./logs.ts`.

* **src/types/common.ts**
  - Add JSDocs for all exported types, enums, interfaces, and type aliases.

* **src/types/logs.ts**
  - Add JSDocs for all exported enums, interfaces, and type aliases.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/blouflashdb/nimiq-rpc/pull/5?shareId=f9988afa-1921-4b0f-8eb9-e81d02f116de).